### PR TITLE
Add CI/CD pipelines

### DIFF
--- a/.github/workflows/plugin_deploy.yml
+++ b/.github/workflows/plugin_deploy.yml
@@ -1,0 +1,41 @@
+name: Kong Plugin Deploy
+
+on:
+  push:
+    branches: 
+      - main
+      - master
+      - cicdupdate
+  pull_request_review:
+    branches: 
+      - main
+      - master
+    types:
+      - submitted
+
+env:
+  EKS_CLUSTER_NAME: aries-default
+  AWS_REGION: af-south-1
+
+jobs:
+  Release:
+    if: github.ref_name	== 'master' || github.ref_name	== 'main' || github.ref_name	== 'cicdupdate' 
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: AWS Login
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_ACCESS_SECRET }}
+          aws-region: ${{ env.AWS_REGION }}
+      -
+        name: Deploy tenant-apikey plugin
+        run: |
+          aws eks --region "${AWS_REGION}" update-kubeconfig --name "${EKS_CLUSTER_NAME}"
+          kubectl create configmap tenant-apikey --from-file=plugins/tenant-apikey -n app

--- a/.github/workflows/plugin_deploy.yml
+++ b/.github/workflows/plugin_deploy.yml
@@ -31,8 +31,8 @@ jobs:
         name: AWS Login
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_ACCESS_SECRET }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
       -
         name: Deploy tenant-apikey plugin


### PR DESCRIPTION
GitHub Actions workflows for deployments to an EKS cluster managed with Terraform from the IaC repository.
Deploys custom Kong plugin as ConfigMap for further usage by Kong in EKS.


GitHub Secrets expected by workflows:
* `AWS_ACCESS_KEY_ID` - AWS Access Key from AWS User with enough permissions to access ECR/EKS. More info on AWS access [here](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
* `AWS_SECRET_ACCESS_KEY` - AWS Secret Access Key from AWS User with enough permissions to access ECR/EKS. More info on AWS access [here](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)